### PR TITLE
OPNS-52: Fix API baseURL and endpoints; Plants/Orders working locally

### DIFF
--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -16,4 +16,16 @@ userSchema.pre('save', async function (next) {
     this.password = await bcrypt.hash(this.password, salt);
 });
 
+// Helper for login
+userSchema.methods.comparePassword = function (candidate) {
+  return bcrypt.compare(candidate, this.password);
+};
+
+// Hide password in JSON
+userSchema.methods.toJSON = function () {
+  const obj = this.toObject();
+  delete obj.password;
+  return obj;
+};
+
 module.exports = mongoose.model('User', userSchema);

--- a/backend/server.js
+++ b/backend/server.js
@@ -11,6 +11,12 @@ const app = express();
 
 app.use(cors());
 app.use(express.json());
+
+// Health probe for VM and Nginx
+app.get('/api/health', (req, res) => {
+  res.json({ ok: true, uptime: process.uptime() });
+});
+
 app.use('/api/auth', require('./routes/authRoutes'));
 app.use('/api/plants', require('./routes/plantRoutes')); // Plants CRUD
 app.use('/api/orders', require('./routes/orderRoutes')); // Orders CRUD

--- a/frontend/src/axiosConfig.jsx
+++ b/frontend/src/axiosConfig.jsx
@@ -2,7 +2,7 @@ import axios from 'axios';
 
 const axiosInstance = axios.create({
      baseURL: 'http://localhost:5001', // local
-  // baseURL: 'http://16.176.185.99:5001', // live
+     // baseURL: 'http://16.176.103.184:5001', // live
   headers: { 'Content-Type': 'application/json' },
 });
 


### PR DESCRIPTION
Previously, `axios` had `/api` in the `baseURL`, while some components called plain `/plants` and `/orders`, causing 404s. This aligns all calls to the backend.